### PR TITLE
Add metricminer.org to sync configuration

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -34,6 +34,7 @@ group:
       fhdsl/ITN_course_search
       cansavvy/cansavvy_website
       ottrproject/metricminer-dashboard
+      ottrproject/metricminer.org
       fhdsl/Intermediate_R
       fhdsl/AnVIL_Poll_2024
       fhdsl/ITN_Workshops_2024

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -3,20 +3,26 @@
 
 group:
   - files:
-      - source: .github/workflows/
-        dest: .github/workflows/
-        deleteOrphaned: true
-        exclude: |
-          send-updates.yml
-          test-send-updates.yml
-          starting-course.yml
-          release-notes.yml
+      # - source: .github/workflows/
+     #   dest: .github/workflows/
+     #   deleteOrphaned: true
+     #   exclude: |
+     #     send-updates.yml
+     #     test-send-updates.yml
+     #     starting-course.yml
+     #     release-notes.yml
       - source: .github/workflows/delete-preview.yml
         dest: .github/workflows/delete-preview.yml
       - source: .github/workflows/render-all.yml
         dest: .github/workflows/render-site.yml
       - source: .github/workflows/pull_request.yml
         dest: .github/workflows/pull_request.yml
+      - source: config_automation.yml
+        dest: config_automation.yml
+      - source: .github/workflows/check-url.yml
+        dest: .github/workflows/check-url.yml
+      - source: .github/workflows/docker-test.yml
+        dest: .github/workflows/docker-test.yml
       - source: config_automation.yml
         dest: config_automation.yml
   # Repositories to receive changes
@@ -46,6 +52,7 @@ group:
       fhdsl/UMich_ITN_Workshop
       fhdsl/ITN_Workshops_2025
       fhdsl/itn-training-metrics
+      opencasestudies/ocs-bp-co2-emissions
 
 ###ADD NEW REPO HERE following the format above#
 


### PR DESCRIPTION
Needed to add metricminer.org to the sync file. We had sent a test sync to the repo, but were getting extra files (render-all) when we should have been getting just render-site (we changed its name), we're testing if this will fix it to just send render-site: commented out the previous workflow sync configuration that sent the whole directory (excluding files) and instead listed just the ones we wanted to send. Also added an ocs to test