### PR TITLE
Update sync.yml with files specific to opencasestudies repos

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -53,17 +53,32 @@ group:
       fhdsl/ITN_Workshops_2025
       fhdsl/itn-training-metrics
       fhsdsl/daseh_instructor_guide
-      opencasestudies/ocs-bp-co2-emissions
 
 ###ADD NEW REPO HERE following the format above#
 
 ### These are custom groups for syncing -- not all files needs to be synced # will update later
-  # - files:
-  #   - source: config_automation.yml
-  #     dest: config_automation.yml
-  #   - source: .github/workflows/pull-request.yml
-  #     dest: .github/workflows/pull-request.yml
-  #   - source: scripts/spell-check.R
-  #     dest: scripts/spell-check.R
-  #   repos: |
-  #     jhudsl/Baltimore_Community_Course
+  - files:
+      - source: .github/workflows/delete-preview.yml
+        dest: .github/workflows/delete-preview.yml
+      - source: .github/workflows/render-all.yml
+        dest: .github/workflows/render-site.yml
+      - source: .github/workflows/pull_request.yml
+        dest: .github/workflows/pull_request.yml
+      - source: config_automation.yml
+        dest: config_automation.yml
+      - source: .github/workflows/check-url.yml
+        dest: .github/workflows/check-url.yml
+      - source: .github/workflows/docker-test.yml
+        dest: .github/workflows/docker-test.yml
+      - source: config_automation.yml
+        dest: config_automation.yml
+      - source: resources/
+        dest: resources
+
+    repos: |
+      opencasestudies/ocs-ripples-ancestry
+      opencasestudies/ocs-bp-template
+      opencasestudies/ocs-template
+      
+      
+      


### PR DESCRIPTION
Rather than running ottr-fy in every ocs repo, sending the workflow files and resources (e.g., dictionary, etc.) to the repos as a sync. Since we'll need some changes to the config and workflows for every repo, sending to the templates so we can make the changes there and send out syncs to the child repos from the templates